### PR TITLE
添加为 Loong Arch Linux 官方仓库打包的初步支持

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -13,6 +13,9 @@ repodir = "/path/to/gitrepo"
 # The path where built packages and signatures are copied to
 # comment out if there's no need to copy built packages
 destdir = "/path/to/pkgdir"
+# By default, lilac refuses to build a package that is in an official group or replaces an official package.
+# If you use lilac to build packages for official repositories, uncomment to ignore the check.
+# official = true
 
 [lilac]
 # this is the name in the mail header and subject
@@ -23,6 +26,11 @@ email = "lilac@example.com"
 master = "Your Name <youremail@example.com>"
 # Set and unsubscribe_address to receive unsubscribe requests
 # unsubscribe_address = "unsubscribe@example.com"
+
+# the default archbuild prefix to be used
+# if not set, falls back to "extra-$(uname -m)", which can be invalid on some platforms (e.g. loongarch64)
+# default_build_prefix = "extra-loong64"
+
 # Set to yes to automatically rebuild packages which failed to build last time
 rebuild_failed_pkgs = true
 git_push = false

--- a/lilac2/building.py
+++ b/lilac2/building.py
@@ -85,6 +85,7 @@ def build_package(
       reap_zombies()
 
     staging = lilacinfo.staging
+    destdir = destdir / lilacinfo.destsubdir
     if staging:
       destdir = destdir / 'staging'
       if not destdir.is_dir():

--- a/lilac2/cmd.py
+++ b/lilac2/cmd.py
@@ -61,7 +61,7 @@ def git_push() -> None:
       break
     except CalledProcessError as e:
       if 'non-fast-forward' in e.output or 'fetch first' in e.output:
-        run_cmd(["git", "pull", "--rebase"])
+        run_cmd(["git", "pull", "--rebase", "origin", get_git_branch()])
       else:
         raise
 

--- a/lilac2/lilacyaml.py
+++ b/lilac2/lilacyaml.py
@@ -103,6 +103,7 @@ def load_lilacinfo(dir: Path) -> LilacInfo:
     time_limit_hours = yamlconf.get('time_limit_hours', 1),
     staging = yamlconf.get('staging', False),
     managed = yamlconf.get('managed', True),
+    destsubdir = yamlconf.get('destsubdir', '')
   )
 
 def expand_alias_arg(value: str) -> str:

--- a/lilac2/pkgbuild.py
+++ b/lilac2/pkgbuild.py
@@ -97,7 +97,7 @@ def load_data(dbpath: Path) -> None:
     db = H.register_syncdb(_G.repo.name, 0)
     _repo_package_versions = {p.name: p.version for p in db.pkgcache}
 
-def check_srcinfo() -> PkgVers:
+def check_srcinfo(official: bool = False) -> PkgVers:
   srcinfo = get_srcinfo().decode('utf-8').splitlines()
   bad_groups = []
   bad_packages = []
@@ -130,7 +130,7 @@ def check_srcinfo() -> PkgVers:
       # the newly built package is not in repos yet - fine
       pass
 
-  if bad_groups or bad_packages:
+  if not official and (bad_groups or bad_packages):
     raise ConflictWithOfficialError(bad_groups, bad_packages)
 
   return pkgvers

--- a/lilac2/typing.py
+++ b/lilac2/typing.py
@@ -39,6 +39,7 @@ class LilacInfo:
   time_limit_hours: float
   staging: bool
   managed: bool
+  destsubdir: str
 
 LilacInfos = Dict[str, LilacInfo]
 

--- a/lilac2/worker.py
+++ b/lilac2/worker.py
@@ -30,6 +30,9 @@ from .lilacyaml import load_lilacinfo
 from .const import _G, PACMAN_DB_DIR, mydir
 from .repo import Repo
 
+from .tools import read_config
+config = read_config()
+
 logger = logging.getLogger(__name__)
 
 class SkipBuild(Exception):
@@ -100,7 +103,8 @@ def lilac_build(
     pkgvers = pkgbuild.check_srcinfo()
     _G.built_version = str(pkgvers)
 
-    default_build_prefix = 'extra-%s' % (platform.machine() or 'x86_64')
+    default_build_prefix = config['lilac'].get('default_build_prefix') or \
+                           'extra-%s' % (platform.machine() or 'x86_64')
     build_prefix = build_prefix or getattr(
       mod, 'build_prefix', default_build_prefix)
     if not isinstance(build_prefix, str):
@@ -204,8 +208,6 @@ def run_build_cmd(cmd: Cmd) -> None:
 def main() -> None:
   enable_pretty_logging('DEBUG')
 
-  from .tools import read_config
-  config = read_config()
   repo = _G.repo = Repo(config)
   pkgbuild.load_data(PACMAN_DB_DIR)
   _G.commit_msg_prefix = repo.commit_msg_prefix

--- a/lilac2/worker.py
+++ b/lilac2/worker.py
@@ -100,7 +100,7 @@ def lilac_build(
       run_cmd(['recv_gpg_keys'])
       vcs_update()
 
-    pkgvers = pkgbuild.check_srcinfo()
+    pkgvers = pkgbuild.check_srcinfo(config['repository'].get('official', False))
     _G.built_version = str(pkgvers)
 
     default_build_prefix = config['lilac'].get('default_build_prefix') or \

--- a/schema-docs/lilac-yaml-schema.yaml
+++ b/schema-docs/lilac-yaml-schema.yaml
@@ -5,15 +5,8 @@ description: Descriptive configuration data for lilac packaging
 type: object
 properties:
   build_prefix:
-    description: The prefix of build command to be used. E.g. extra-x86_64, multilib or archlinuxcn-x86_64.
+    description: The prefix of build command to be used instead of default_build_prefix. E.g. extra-x86_64, multilib or archlinuxcn-x86_64.
     type: string
-    default: "extra-$(uname -m)"
-    enum:
-      - extra-x86_64
-      - archlinuxcn-x86_64
-      - multilib
-      - multilib-archlinuxcn
-      - extra-aarch64
   pre_build:
     description: Name of function to be used as the pre_build function.
     type: string
@@ -129,6 +122,10 @@ properties:
     description: Whether to stage the package in a "staging" subdirectory
     type: boolean
     default: false
+  destsubdir:
+    description: Place the package in this subdirectory
+    type: string
+    default: ""
   managed:
     description: Whether the package should be built by lilac or not
     type: boolean


### PR DESCRIPTION
#### 具体内容
1. 为 lilac.yaml 增加 destsubdir 选项
    - 原版 lilac 已经具备了将软件包放入 staging 子目录的功能，但其设计并不是用来满足分仓库需求的，因此额外增加 destsubdir 选项以灵活指定子目录，从而满足 Loong Arch Linux 多仓库打包的需求。
2. 在全局 config 中增加 default_build_prefix 设置
    - lilac 默认选择的 default_build_prefix 是 `extra-<当前架构>`，而 `loongarch64` 的架构名和 Loong Arch Linux 打包用的 `loong64` 架构名不一致，因此原版 lilac 不能在缺省的情况下正确选择 `loong64` 架构的 build_prefix。简单起见，这里并没有修改 lilac 的架构检测逻辑，而是让 default_build_prefix 可以手动在 config.toml 中指定，使其不再依赖架构检测，同时也为 testing 的打包提供了一定的便利。
3. 增加绕过官方仓库检测的方式
    - 原版 lilac 会在检测到所打的包取代官方软件包或在官方包组中时抛出错误。为了提供官方仓库的打包支持，在 config.toml 中增加了 official 选项，将其设置为 true 时即可绕过上述检测。
4. 在解决 git push 的冲突时指定从 origin 的同名分支中拉取
    - 在给 Loong Arch Linux 打包时，我们计划让 lilac 从 dev 分支拉取更改，打包完成后推送到另一分支。测试过程中发现 lilac 要求使用 master 或 main 分支，这一点与预想的不同，但也不难满足，因此没有更改 lilac 的这个设定。但是将本地的 master 分支设置为追踪 origin/dev 后，lilac 的 `git_push` 函数在处理冲突时会反复拉取没有冲突的 dev 分支而陷入死循环。为了让 lilac 正确处理冲突，将该函数中的 `git pull --rebase` 命令改为 `git pull --rebase origin <当前分支名>`。

初步的打包测试仓库：https://github.com/SamLukeYes/lilac-loong-test

#### TODO: 更新文档
- config.toml
    - [X] default_build_prefix
    - [X] official
- lilac.yaml
    - [X] destsubdir
    - [X] build_prefix (更新对默认值的描述)