### PR TITLE
Loong Arch Linux 官方仓库打包的相关功能（第二部分）

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -51,6 +51,11 @@ max_concurrency = 1
 # set proxy for nvchecker
 # proxy = "http://localhost:8000"
 
+# Replace any archpkg entry with an alpm entry using this specific dbpath
+# Useful to avoid too many requests being sent to the Arch server if there are many packages with archpkg entries in the repo
+# You can automatically update the db in prerun
+# archpkg_dbpath = "~/.lilac/pacmandb/archpkg"
+
 [smtp]
 # You can configure a SMTP account here; it defaults to localhost:53
 #host = ""

--- a/lilac
+++ b/lilac
@@ -565,6 +565,8 @@ def main_may_raise(
     raise Exception('repo not on master or main, aborting.')
 
   pkgbuild.update_data(PACMAN_DB_DIR)
+  if archpkg_dbpath := config['nvchecker'].get('archpkg_dbpath'):
+    _G.ARCHPKG_DB_DIR = Path(archpkg_dbpath).expanduser()
 
   if dburl := config['lilac'].get('dburl'):
     import sqlalchemy

--- a/lilac
+++ b/lilac
@@ -242,40 +242,79 @@ def start_build(
   max_concurrency: int,
 ) -> None:
   # built is used to collect built package names
-  sorter, depmap = packages_with_depends(repo)
+
+  rebuild_on_soname = defaultdict(lambda: defaultdict(dict))
+  for p, info in repo.lilacinfos.items():
+    try:
+      for item in info.update_on_soname:
+        pkgname = item['pkgname']
+        pkgbase = item.get('pkgbase', pkgname)
+        for lib in item['libs']:
+          rebuild_on_soname[pkgbase][lib][p] = pkgname
+    except Exception as e:
+      repo.send_error_report(
+        info, subject='%s: failed to load update_on_soname', exc=e,
+      )
+
+  libver_cache = str(mydir / 'libver.json')
+  libvers = defaultdict(lambda: defaultdict(str))
+  if os.path.isfile(libver_cache):
+    with open(libver_cache) as f:
+      libvers.update(json.load(f))
 
   try:
-    buildsorter = BuildSorter(sorter, depmap)
     futures: dict[Future, str] = {}
+    global build_reasons
     with ThreadPoolExecutor(
       max_workers = max_concurrency,
       initializer = setup_thread,
     ) as executor:
-      while True:
-        pkgs = try_pick_some(
-          repo,
-          buildsorter, failed,
-          running = frozenset(futures.values()),
-          limit = max_concurrency - len(futures),
-        )
-        for pkg in pkgs:
-          fu = executor.submit(
-            build_it, pkg, repo, buildsorter, built, failed)
-          futures[fu] = pkg
+      while build_reasons:
+        sorter, depmap = packages_with_depends(repo)
+        buildsorter = BuildSorter(sorter, depmap)
+        packages_to_build = set(build_reasons)
+        rebuild_reasons = defaultdict(list)
+        while True:
+          pkgs = try_pick_some(
+            repo,
+            buildsorter, failed,
+            running = frozenset(futures.values()),
+            limit = max_concurrency - len(futures),
+          )
+          for pkg in pkgs:
+            fu = executor.submit(
+              build_it, pkg, repo, buildsorter, built, failed)
+            futures[fu] = pkg
 
-        if not futures:
-          # no task is running: we're done
-          break
+          if not futures:
+            # no task is running: we're done
+            break
 
-        done, pending = futures_wait(futures, return_when=FIRST_COMPLETED)
-        for fu in done:
-          del futures[fu]
-          fu.result()
+          done, pending = futures_wait(futures, return_when=FIRST_COMPLETED)
+          for fu in done:
+            pkg = futures[fu]
+            if soname_change := fu.result():
+              for lib in soname_change:
+                if libvers[pkg][lib] != (libver := soname_change[lib]):
+                  packages_to_rebuild = rebuild_on_soname[pkg][lib]
+                  logger.info(f'Scheduling rebuild for {lib}={libver}: {list(packages_to_rebuild)}')
+                  packages_to_build -= (built | set(failed) | set(futures.values()))
+                  for p, d in packages_to_rebuild.items():
+                    reason = BuildReason.UpdatedSoname(pkg, d, lib, libver)
+                    if p in packages_to_build:
+                      build_reasons[p].append(reason)
+                    else:
+                      rebuild_reasons[p].append(reason)
+            del futures[fu]
+          # at least one task is done, try pick new tasks
 
-        # at least one task is done, try pick new tasks
+        build_reasons = rebuild_reasons
+        # start build again if there are packages to rebuild
 
   except KeyboardInterrupt:
     logger.info('keyboard interrupted, bye~')
+  
+  json.dump(libvers, open(libver_cache, 'w'))
 
 def try_pick_some(
   repo: Repo,
@@ -352,7 +391,7 @@ def try_pick_some(
 def build_it(
   pkg: str, repo: Repo, buildsorter: BuildSorter,
   built: set[str], failed: dict[str, tuple[str, ...]],
-) -> None:
+) -> Optional[Dict[str, str]]:
   logger.info('building %s', pkg)
   logfile = logdir / f'{pkg}.log'
 
@@ -361,12 +400,19 @@ def build_it(
       db.mark_pkg_as(s, pkg, 'building')
       db.build_updated(s)
 
+  depends = BUILD_DEPMAP.get(pkg, set())
+  for reason in build_reasons[pkg]:
+    if isinstance(reason, BuildReason.UpdatedSoname):
+      dep = Dependency(repo.repodir/reason.pkgbase, reason.pkgname)
+      depends.add(dep)
+      depends.update(BUILD_DEPMAP.get(dep.pkgname, set()))
+
   r, version = build_package(
     pkg, repo.lilacinfos[pkg],
     update_info = nvdata[pkg],
     bindmounts = repo.bindmounts,
     tmpfs = repo.tmpfs,
-    depends = BUILD_DEPMAP.get(pkg, ()),
+    depends = depends,
     repo = REPO,
     myname = MYNAME,
     destdir = DESTDIR,
@@ -469,8 +515,23 @@ def build_it(
 
   if r:
     built.add(pkg)
+    return check_soname_change(logfile)
   elif pkg not in failed:
     failed[pkg] = ()
+
+def check_soname_change(logfile: str) -> dict[str, str]:
+  ret = dict()
+  reading = False
+  for line in open(logfile):
+    if 'Sonames differ' in line:
+      reading = True
+      continue
+    if reading and line.startswith('lib'):
+      lib_and_ver = line.split()[-1].split('-')[0].split('=')
+      ret[lib_and_ver[0]] = lib_and_ver[1]
+    else:
+      reading = False
+  return ret
 
 WORKER_NO = 0
 WORKER_NO_LOCK = threading.Lock()

--- a/lilac
+++ b/lilac
@@ -534,6 +534,8 @@ def check_soname_change(logfile: str) -> dict[str, str]:
       continue
     if reading and line.startswith('lib'):
       lib_and_ver = line.split()[-1].split('=')
+      if not lib_and_ver[0].startswith('lib'):
+        continue  # the lib no longer exists
       ret[lib_and_ver[0]] = lib_and_ver[1].split('-')[0]
     else:
       reading = False

--- a/lilac
+++ b/lilac
@@ -583,15 +583,17 @@ def main_may_raise(
     for i in info.update_on_build:
       if_this_then_those[i.pkgbase].add(p)
   more_pkgs = set()
-  count = 0
   for p in build_reasons:
     if pkgs := if_this_then_those.get(p):
       more_pkgs.update(pkgs)
-  while len(more_pkgs) != count: # has new
-    count = len(more_pkgs)
+  while True:
+    add_to_more_pkgs = set()
     for p in more_pkgs:
       if pkgs := if_this_then_those.get(p):
-        more_pkgs.update(pkgs)
+        add_to_more_pkgs.update(pkgs)
+    if add_to_more_pkgs.issubset(more_pkgs):
+      break
+    more_pkgs.update(add_to_more_pkgs)
   for p in more_pkgs:
     update_on_build = REPO.lilacinfos[p].update_on_build
     build_reasons[p].append(BuildReason.OnBuild(update_on_build))

--- a/lilac
+++ b/lilac
@@ -532,8 +532,8 @@ def check_soname_change(logfile: str) -> dict[str, str]:
       reading = True
       continue
     if reading and line.startswith('lib'):
-      lib_and_ver = line.split()[-1].split('-')[0].split('=')
-      ret[lib_and_ver[0]] = lib_and_ver[1]
+      lib_and_ver = line.split()[-1].split('=')
+      ret[lib_and_ver[0]] = lib_and_ver[1].split('-')[0]
     else:
       reading = False
   return ret

--- a/lilac
+++ b/lilac
@@ -411,7 +411,6 @@ def build_it(
     if isinstance(reason, BuildReason.UpdatedSoname):
       dep = Dependency(repo.repodir/reason.pkgbase, reason.pkgname)
       depends.add(dep)
-      depends.update(BUILD_DEPMAP.get(dep.pkgname, set()))
 
   r, version = build_package(
     pkg, repo.lilacinfos[pkg],

--- a/lilac
+++ b/lilac
@@ -257,7 +257,7 @@ def start_build(
       )
 
   libver_cache = str(mydir / 'libver.json')
-  libvers = defaultdict(lambda: defaultdict(str))
+  libvers = defaultdict(dict)
   if os.path.isfile(libver_cache):
     with open(libver_cache) as f:
       libvers.update(json.load(f))
@@ -295,7 +295,7 @@ def start_build(
             pkg = futures[fu]
             if soname_change := fu.result():
               for lib in soname_change:
-                if libvers[pkg][lib] != (libver := soname_change[lib]):
+                if libvers[pkg].get(lib, '') != (libver := soname_change[lib]):
                   packages_to_rebuild = rebuild_on_soname[pkg][lib]
                   logger.info(f'Scheduling rebuild for {lib}={libver}: {list(packages_to_rebuild)}')
                   packages_to_build -= (built | set(failed) | set(futures.values()))
@@ -305,6 +305,7 @@ def start_build(
                       build_reasons[p].append(reason)
                     else:
                       rebuild_reasons[p].append(reason)
+              libvers[pkg] = soname_change
             del futures[fu]
           # at least one task is done, try pick new tasks
 

--- a/lilac
+++ b/lilac
@@ -395,6 +395,12 @@ def build_it(
   logger.info('building %s', pkg)
   logfile = logdir / f'{pkg}.log'
 
+  if logfile.is_file():   # rebuild triggered by soname change
+    logfile = logdir / f'{pkg}_rebuild.log'
+    if logfile.is_file():
+      # rebuild is only expected to trigger once
+      logger.warning('logfile %s already exists, overwriting', logfile)
+
   if db.USE:
     with db.get_session() as s:
       db.mark_pkg_as(s, pkg, 'building')

--- a/lilac
+++ b/lilac
@@ -532,13 +532,13 @@ def check_soname_change(logfile: str) -> dict[str, str]:
     if 'Sonames differ' in line:
       reading = True
       continue
-    if reading and line.startswith('lib'):
-      lib_and_ver = line.split()[-1].split('=')
-      if not lib_and_ver[0].startswith('lib'):
-        continue  # the lib no longer exists
-      ret[lib_and_ver[0]] = lib_and_ver[1].split('-')[0]
-    else:
-      reading = False
+    if reading:
+      change = line.split()
+      if change[-1].startswith('lib'):
+        lib_and_ver = change[-1].split('=')
+        ret[lib_and_ver[0]] = lib_and_ver[1].split('-')[0]
+      elif not change[0].startswith('lib'):
+        reading = False
   return ret
 
 WORKER_NO = 0

--- a/lilac
+++ b/lilac
@@ -521,7 +521,12 @@ def build_it(
 
   if r:
     built.add(pkg)
-    return check_soname_change(logfile)
+    try:
+      return check_soname_change(logfile)
+    except Exception as e:
+      repo.send_error_report(
+        pkg, subject='%s failed to check soname change', exc=e,
+      )
   elif pkg not in failed:
     failed[pkg] = ()
 

--- a/lilac2/lilacyaml.py
+++ b/lilac2/lilacyaml.py
@@ -149,6 +149,12 @@ def parse_update_on(
     source = entry.get('source')
     if source == 'alpm' or source == 'alpmfiles':
       entry.setdefault('dbpath', str(PACMAN_DB_DIR))
+    try:
+      if _G.ARCHPKG_DB_DIR and source == 'archpkg':
+        entry['source'] = 'alpm'
+        entry['dbpath'] = str(_G.ARCHPKG_DB_DIR)
+    except AttributeError:
+      pass
 
     ret_update.append(entry)
 

--- a/lilac2/lilacyaml.py
+++ b/lilac2/lilacyaml.py
@@ -97,6 +97,7 @@ def load_lilacinfo(dir: Path) -> LilacInfo:
     maintainers = yamlconf.get('maintainers', []),
     update_on = update_ons,
     update_on_build = [OnBuildEntry(**x) for x in yamlconf.get('update_on_build', [])],
+    update_on_soname = yamlconf.get('update_on_soname', []),
     throttle_info = throttle_info,
     repo_depends = yamlconf.get('repo_depends', []),
     repo_makedepends = yamlconf.get('repo_makedepends', []),

--- a/lilac2/nomypy.py
+++ b/lilac2/nomypy.py
@@ -115,4 +115,11 @@ class OnBuild(BuildReason):
     d['name'] = self.__class__.__name__
     return d
 
-del NvChecker, UpdatedFailed, UpdatedPkgrel, Depended, FailedByDeps, Cmdline, OnBuild
+class UpdatedSoname(BuildReason):
+  def __init__(self, pkgbase: str, pkgname: str, lib: str, libver: str) -> None:
+    self.pkgbase = pkgbase
+    self.pkgname = pkgname
+    self.lib = lib
+    self.libver = libver
+
+del NvChecker, UpdatedFailed, UpdatedPkgrel, Depended, FailedByDeps, Cmdline, OnBuild, UpdatedSoname

--- a/lilac2/typing.py
+++ b/lilac2/typing.py
@@ -33,6 +33,7 @@ class LilacInfo:
   maintainers: list[dict[str, str]]
   update_on: NvEntries
   update_on_build: list[OnBuildEntry]
+  update_on_soname: list[dict[str, Any]]
   throttle_info: dict[int, datetime.timedelta]
   repo_depends: list[tuple[str, str]]
   repo_makedepends: list[tuple[str, str]]

--- a/schema-docs/lilac-yaml-schema.yaml
+++ b/schema-docs/lilac-yaml-schema.yaml
@@ -95,6 +95,27 @@ properties:
       required:
         - pkgbase
     minItems: 0
+  update_on_soname:
+    description: Rebuild if sonames in a managed package changes. The packages can be absent from "repo_depends" to handle circular dependencies.
+    type: array
+    items:
+      type: object
+      description: Libraries provided by a package (base). The package should be managed by lilac and use a "build_prefix" providing itself. It should also be in "repo_depends" unless it should be built after the current package due to circular dependency.
+      required:
+        - pkgname
+        - libs
+      properties:
+        pkgbase:
+          type: string
+          default: pkgname
+          description: Package base (directory) name
+        pkgname:
+          type: string
+          description: Package name
+        libs:
+          type: array
+          items:
+            type: string
   maintainers:
     description: List of maintainers for receiving email notifications
     type: array


### PR DESCRIPTION
### 内容
1. 修复了一个在 lilac.yaml 中使用 update_on_build 可能会使 lilac 直接报错退出的 bug（已提交至上游）
    - https://github.com/archlinuxcn/lilac/pull/204

2. 为 lilac.yaml 增加了 update_on_soname 选项
    - 原版 lilac 根据库版本变化触发 rebuild 的机制依赖于 nvchecker。这意味着在 lilac 管理的软件包中库版本有变时，其他依赖这个库的软件包需要等下次 lilac 运行时才会触发 rebuild。为了解决这个问题，这里加入了一个根据库版本变化*在打包过程中*触发 rebuild 的机制，根据打包日志中 checkpkg 输出来触发在 update_on_soname 中指定了相应共享库的包 rebuild。

3. 增加了将所有 update_on 中的 archpkg 视为 alpm 的方法
    - 当 lilac 运行 nvchecker 时，lilac.yaml 中每有一个 archpkg 的 update_on 项目，就会向 Arch Linux 服务器发一个请求。在管理 Arch 的衍生发行版仓库时有大量从上游检查更新的需求，但如果每个包都用 archpkg 检查更新就会导致请求过多。lilac 的源码仓库中有一个从 archpkg 迁移至 alpm 的脚本，这样就能快速地从 pacman 数据库中检查更新，但衍生发行版向上游 Arch 检查更新还需要使用不同的软件包数据库。为了简单起见，我们仍然使用 archpkg 这个名称，但是在 config.toml 中加入 archpkg_dbpath 设置。如果在 config.toml 中设置了 archpkg_dbpath，那么 lilac 会将所有 update_on 中的 archpkg 视为 alpm，并将 dbpath 设置为 archpkg_dbpath 的值。这样一来，只需在 prerun 中从上游更新这个数据库，nvchecker 就能用这个数据库检查上游更新了。